### PR TITLE
City Forecast Endpoint with Validation for API Key

### DIFF
--- a/models/forecast_object.js
+++ b/models/forecast_object.js
@@ -1,0 +1,10 @@
+class ForecastObject {
+  constructor(location, forecast){
+    this.location = location
+    this.currently = forecast.currently
+    this.hourly = forecast.hourly
+    this.daily = forecast.daily
+  }
+}
+
+module.exports = ForecastObject

--- a/models/user_object.js
+++ b/models/user_object.js
@@ -1,10 +1,19 @@
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
 class UserObject {
   constructor(){
 
   }
   async validKey(api_key){
-    console.log(api_key)
-    if(typeof api_key === 'undefined'){ return false }
+    if (typeof api_key === 'undefined'){ return false }
+
+    database('users').where('api_key', api_key)
+      .then(user => {
+      if (user.length === 0) { return false }
+      else { return true }
+    });
   }
 }
 

--- a/models/user_object.js
+++ b/models/user_object.js
@@ -1,0 +1,11 @@
+class UserObject {
+  constructor(){
+
+  }
+  async validKey(api_key){
+    console.log(api_key)
+    if(typeof api_key === 'undefined'){ return false }
+  }
+}
+
+module.exports = UserObject

--- a/models/user_object.js
+++ b/models/user_object.js
@@ -4,16 +4,16 @@ const database = require('knex')(configuration);
 
 class UserObject {
   constructor(){
-
   }
   async validKey(api_key){
     if (typeof api_key === 'undefined'){ return false }
+    let user = await database('users').where('api_key', api_key)
 
-    database('users').where('api_key', api_key)
-      .then(user => {
-      if (user.length === 0) { return false }
-      else { return true }
-    });
+    if (user.length === 0)
+      { return false
+    } else
+      { return true
+    };
   }
 }
 

--- a/models/user_object.js
+++ b/models/user_object.js
@@ -7,6 +7,7 @@ class UserObject {
   }
   async validKey(api_key){
     if (typeof api_key === 'undefined'){ return false }
+
     let user = await database('users').where('api_key', api_key)
 
     if (user.length === 0)

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -1,19 +1,19 @@
-var express = require('express');
-var router = express.Router();
-
-const environment = process.env.NODE_ENV || 'development';
-const configuration = require('../../../knexfile')[environment];
-const database = require('knex')(configuration);
-
-
-router.get('/', (request, response) => {
-  database('favorites').select()
-    .then((favorites) => {
-      response.status(200).json(favorites);
-    })
-    .catch((error) => {
-      response.status(500).json({ error });
-    });
-});
-
-module.exports = router;
+// var express = require('express');
+// var router = express.Router();
+//
+// const environment = process.env.NODE_ENV || 'development';
+// const configuration = require('../../../knexfile')[environment];
+// const database = require('knex')(configuration);
+//
+//
+// router.get('/', (request, response) => {
+//   database('favorites').select()
+//     .then((favorites) => {
+//       response.status(200).json(favorites);
+//     })
+//     .catch((error) => {
+//       response.status(500).json({ error });
+//     });
+// });
+//
+// module.exports = router;

--- a/routes/api/v1/forecast.js
+++ b/routes/api/v1/forecast.js
@@ -8,23 +8,27 @@ const database = require('knex')(configuration);
 let GeoCodingService = require('../../../services/geo_coding_service.js');
 let DarkSkyService = require('../../../services/dark_sky_service.js');
 let UserObject = require('../../../models/user_object.js');
+let ForecastObject = require('../../../models/forecast_object.js');
 
 let geoCodingService = new GeoCodingService();
 let darkSkyService = new DarkSkyService();
 let userObject = new UserObject();
 
-router.get('/', async function (request, response, next) {
+router.get('/', async function (request, response) {
 
   let api_key = request.body.api_key
   let valid_key = await userObject.validKey(api_key)
 
-  if (valid_key === true){
+  if (valid_key === true ){
+    
     let location = await request.query.location
     let coordinates = await geoCodingService.getCoordinatesAsync(location);
     let forecast = await darkSkyService.getForecast(coordinates);
-    return response.status(200).json(forecast);
+    let forcastFormat = await new ForecastObject(location, forecast);
+
+    return response.status(200).json(forcastFormat);
   } else {
-    return response.status(404).send("error");
+    return response.status(404).send("Unauthorized");
   };
 })
 

--- a/routes/api/v1/forecast.js
+++ b/routes/api/v1/forecast.js
@@ -6,17 +6,25 @@ const configuration = require('../../../knexfile')[environment];
 const database = require('knex')(configuration);
 
 let GeoCodingService = require('../../../services/geo_coding_service.js');
-let geoCodingService = new GeoCodingService();
-
 let DarkSkyService = require('../../../services/dark_sky_service.js');
+let UserObject = require('../../../models/user_object.js');
+
+let geoCodingService = new GeoCodingService();
 let darkSkyService = new DarkSkyService();
+let userObject = new UserObject();
 
 router.get('/', async function (request, response, next) {
+
+  let api_key = request.body.api_key
+  let valid_key = await userObject.validKey(api_key)
+  console.log(valid_key)
+
   let location = await request.query.location
   let coordinates = await geoCodingService.getCoordinatesAsync(location);
   let forecast = await darkSkyService.getForecast(coordinates);
-  
+
   response.status(200).json(forecast);
+
 })
 
 module.exports = router;

--- a/routes/api/v1/forecast.js
+++ b/routes/api/v1/forecast.js
@@ -17,14 +17,15 @@ router.get('/', async function (request, response, next) {
 
   let api_key = request.body.api_key
   let valid_key = await userObject.validKey(api_key)
-  console.log(valid_key)
 
-  let location = await request.query.location
-  let coordinates = await geoCodingService.getCoordinatesAsync(location);
-  let forecast = await darkSkyService.getForecast(coordinates);
-
-  response.status(200).json(forecast);
-
+  if (valid_key === true){
+    let location = await request.query.location
+    let coordinates = await geoCodingService.getCoordinatesAsync(location);
+    let forecast = await darkSkyService.getForecast(coordinates);
+    return response.status(200).json(forecast);
+  } else {
+    return response.status(404).send("error");
+  };
 })
 
 module.exports = router;


### PR DESCRIPTION
Created endpoint `api/v1/forecast` that returns the forecast for a specific city. Location is passed thru the params. Ex `api/v1/forecast?location=denver,co`

A valid api_key must be passed in the body of the request. A new UserObject class was created with a function to valid the api_key. If the api_key is valid, then the proper requests are made to the GeoCoding and DarkSky service. The data from the DarkSky service is formatted by the new ForecastObject class and displayed in the endpoint as JSON with 200 status. 

If an invalid api_key is valid, a 404 status is rendered with the message 'Unauthorized'. 

Endpoint tested in Postman. 

Still need to create sad path if location in the params is invalid. 