### PR TITLE
Favoriting Location with Validation for API Key

### DIFF
--- a/models/user_object.js
+++ b/models/user_object.js
@@ -8,7 +8,6 @@ class UserObject {
   async validKey(api_key){
     if (typeof api_key === 'undefined'){ return false }
     let user = await database('users').where('api_key', api_key)
-
     return user.length !== 0
   }
 
@@ -16,11 +15,15 @@ class UserObject {
     return database('favorites').where('user_id', userId[0].id).select('location')
   }
 
+  async findUserByApiKey(apiKey){
+    return database('users').where('api_key', apiKey);
+  }
+
   async findUserIdByApiKey(apiKey){
     return database('users').where('api_key', apiKey).select('id');
   }
 
-  async addFavoriteLocation(userId){
+  async addFavoriteLocation(userId, location){
     return database('favorites').insert({location: location, user_id: userId[0].id})
   }
 }

--- a/models/user_object.js
+++ b/models/user_object.js
@@ -7,14 +7,12 @@ class UserObject {
   }
   async validKey(api_key){
     if (typeof api_key === 'undefined'){ return false }
-
     let user = await database('users').where('api_key', api_key)
-
     return user.length !== 0
   }
-  
+
   async favoriteLocations(userId){
-    return await database('favorites').where('user_id', userId[0].id).select('location')
+    return database('favorites').where('user_id', userId[0].id).select('location')
   }
 
   async findUserIdByApiKey(apiKey){

--- a/models/user_object.js
+++ b/models/user_object.js
@@ -12,6 +12,7 @@ class UserObject {
 
     return user.length !== 0
   }
+  
   async favoriteLocations(userId){
     return await database('favorites').where('user_id', userId[0].id).select('location')
   }

--- a/models/user_object.js
+++ b/models/user_object.js
@@ -8,6 +8,7 @@ class UserObject {
   async validKey(api_key){
     if (typeof api_key === 'undefined'){ return false }
     let user = await database('users').where('api_key', api_key)
+
     return user.length !== 0
   }
 
@@ -17,6 +18,10 @@ class UserObject {
 
   async findUserIdByApiKey(apiKey){
     return database('users').where('api_key', apiKey).select('id');
+  }
+
+  async addFavoriteLocation(userId){
+    return database('favorites').insert({location: location, user_id: userId[0].id})
   }
 }
 

--- a/presenters/forecast_presenter.js
+++ b/presenters/forecast_presenter.js
@@ -13,18 +13,21 @@ const darkSkyService = new DarkSkyService();
 class ForecastPresenter {
   constructor(){ }
 
+  async forecastData(location){
+    let coordinates = await geoCodingService.getCoordinatesAsync(location);
+    return darkSkyService.getForecast(coordinates);
+  }
+
   async favoriteLocationsAsync(favoriteLocations){
     let favoriteLocationsFormat = await Promise.all(favoriteLocations.map( async (location) => {
-      let coordinates = await geoCodingService.getCoordinatesAsync(location.location);
-      let forecast = await darkSkyService.getForecast(coordinates);
+      let forecast = await this.forecastData(location.location);
       return new ForecastCurrentlyObject(location.location, forecast);
     }));
     return favoriteLocationsFormat;
   }
 
   async locationAsync(location){
-    let coordinates = await geoCodingService.getCoordinatesAsync(location);
-    let forecast = await darkSkyService.getForecast(coordinates);
+    let forecast = await this.forecastData(location);
     return new ForecastObject(location, forecast);
   }
 }

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -28,12 +28,11 @@ router.get('/', async function (request, response) {
 
 router.post('/', async function (request, response) {
   let apiKey = request.body.api_key
-  let validKey = await userObject.validKey(apiKey)
+  let user = await userObject.findUserByApiKey(apiKey)
 
-  if ( validKey === true ){
+  if ( user !== 'undefined'){
     let location = await request.body.location
-    let userId = await userObject.findUserIdByApiKey(apiKey)
-    userObject.addFavoriteLocation(userId)
+    userObject.addFavoriteLocation(user, location)
     return response.status(200).send({messsage: `${location} has been added to your favorites`})
   } else {
     return response.status(404).send("Unauthorized");

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -27,19 +27,17 @@ router.get('/', async function (request, response) {
 })
 
 router.post('/', async function (request, response) {
-
   let apiKey = request.body.api_key
   let validKey = await userObject.validKey(apiKey)
 
-  let location = await request.body.location
-  let userId = await userObject.findUserIdByApiKey(apiKey)
-
-  database('favorites').insert({location: location, user_id: userId[0].id})
-      .then( result => {
-          response.json({ success: true, message: 'ok' })
-       }).catch (error => {
-        return response.status(404).send("Unauthorized");
-       })
+  if ( validKey === true ){
+    let location = await request.body.location
+    let userId = await userObject.findUserIdByApiKey(apiKey)
+    userObject.addFavoriteLocation(userId)
+    return response.status(200).send({messsage: `${location} has been added to your favorites`})
+  } else {
+    return response.status(404).send("Unauthorized");
+  };
 })
 
 module.exports = router;

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -13,16 +13,14 @@ const forecastPresenter = new ForecastPresenter();
 
 router.get('/', async function (request, response) {
   let apiKey = request.body.api_key
-  let validKey = await userObject.validKey(apiKey)
+  let user = await userObject.findUserByApiKey(apiKey)
 
-  if ( validKey === true ){
-    let userId = await userObject.findUserIdByApiKey(apiKey)
-    let favoriteLocations = await userObject.favoriteLocations(userId)
+  if ( user !== 'undefined'){
+    let favoriteLocations = await userObject.favoriteLocations(user)
     let favoriteLocationsData = await forecastPresenter.favoriteLocationsAsync(favoriteLocations);
-
     return response.status(200).json(favoriteLocationsData);
   } else {
-    return response.status(404).send("Unauthorized");
+    return response.status(401).send("Unauthorized");
   };
 })
 
@@ -35,7 +33,7 @@ router.post('/', async function (request, response) {
     userObject.addFavoriteLocation(user, location)
     return response.status(200).send({messsage: `${location} has been added to your favorites`})
   } else {
-    return response.status(404).send("Unauthorized");
+    return response.status(401).send("Unauthorized");
   };
 })
 

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -26,4 +26,20 @@ router.get('/', async function (request, response) {
   };
 })
 
+router.post('/', async function (request, response) {
+
+  let apiKey = request.body.api_key
+  let validKey = await userObject.validKey(apiKey)
+
+  let location = await request.body.location
+  let userId = await userObject.findUserIdByApiKey(apiKey)
+
+  database('favorites').insert({location: location, user_id: userId[0].id})
+      .then( result => {
+          response.json({ success: true, message: 'ok' })
+       }).catch (error => {
+        return response.status(404).send("Unauthorized");
+       })
+})
+
 module.exports = router;

--- a/routes/api/v1/forecast.js
+++ b/routes/api/v1/forecast.js
@@ -13,10 +13,10 @@ const forecastPresenter = new ForecastPresenter();
 
 router.get('/', async function (request, response) {
 
-  let api_key = request.body.api_key
-  let valid_key = await userObject.validKey(api_key)
+  let apiKey = request.body.api_key
+  let validKey = await userObject.validKey(apiKey)
 
-  if (valid_key === true){
+  if (validKey === true){
     let location = await request.query.location
     let locationData = await forecastPresenter.locationAsync(location);
 

--- a/routes/api/v1/forecast.js
+++ b/routes/api/v1/forecast.js
@@ -14,12 +14,11 @@ const forecastPresenter = new ForecastPresenter();
 router.get('/', async function (request, response) {
 
   let apiKey = request.body.api_key
-  let validKey = await userObject.validKey(apiKey)
+  let user = await userObject.findUserByApiKey(apiKey)
 
-  if (validKey === true){
+  if ( user !== 'undefined'){
     let location = await request.query.location
     let locationData = await forecastPresenter.locationAsync(location);
-
     return response.status(200).json(locationData);
   } else {
     return response.status(401).send("Unauthorized");

--- a/services/dark_sky_service.js
+++ b/services/dark_sky_service.js
@@ -9,8 +9,7 @@ class DarkSkyService {
     let longitude = await coordinates.lng
 
     let response = await fetch(`${this.baseUrl}/${process.env.DARKSKY_API_KEY}/${latitude},${longitude}`)
-    let data = await response.json()
-    return data;
+    return response.json();
   }
 }
 


### PR DESCRIPTION
Created POST endpoint `api/v1/favorites` that post a user's favorited city to the favorite table. The location and api_key is passed thru the body. 

A valid api_key must be passed in the body of the request. If an invalid api_key is valid, a 401 status is rendered with the message 'Unauthorized'.

Logic to check if api_key valid is restructured. In the UserObject model, a new function findUserByApiKey. Function takes in api_key passed in through body. If valid, new function return user object. If a user object is returned to the router, then the location is added to the database. 

Logic updated for GET forecast endpoint and GET favorites endpoint as well. Dead functions removed from UserObject model. 

Endpoint tested in Postman.
