### PR TITLE
DELETE Favorite Endpoint with Validation for API Key

### DIFF
--- a/models/user_object.js
+++ b/models/user_object.js
@@ -5,11 +5,6 @@ const database = require('knex')(configuration);
 class UserObject {
   constructor(){
   }
-  // async validKey(api_key){
-  //   if (typeof api_key === 'undefined'){ return false }
-  //   let user = await database('users').where('api_key', api_key)
-  //   return user.length !== 0
-  // }
 
   async favoriteLocations(userId){
     return database('favorites').where('user_id', userId[0].id).select('location')
@@ -18,10 +13,6 @@ class UserObject {
   async findUserByApiKey(apiKey){
     return database('users').where('api_key', apiKey);
   }
-
-  // async findUserIdByApiKey(apiKey){
-  //   return database('users').where('api_key', apiKey).select('id');
-  // }
 
   async addFavoriteLocation(user, location){
     return database('favorites').insert({location: location, user_id: user[0].id})

--- a/models/user_object.js
+++ b/models/user_object.js
@@ -5,11 +5,11 @@ const database = require('knex')(configuration);
 class UserObject {
   constructor(){
   }
-  async validKey(api_key){
-    if (typeof api_key === 'undefined'){ return false }
-    let user = await database('users').where('api_key', api_key)
-    return user.length !== 0
-  }
+  // async validKey(api_key){
+  //   if (typeof api_key === 'undefined'){ return false }
+  //   let user = await database('users').where('api_key', api_key)
+  //   return user.length !== 0
+  // }
 
   async favoriteLocations(userId){
     return database('favorites').where('user_id', userId[0].id).select('location')
@@ -19,12 +19,16 @@ class UserObject {
     return database('users').where('api_key', apiKey);
   }
 
-  async findUserIdByApiKey(apiKey){
-    return database('users').where('api_key', apiKey).select('id');
+  // async findUserIdByApiKey(apiKey){
+  //   return database('users').where('api_key', apiKey).select('id');
+  // }
+
+  async addFavoriteLocation(user, location){
+    return database('favorites').insert({location: location, user_id: user[0].id})
   }
 
-  async addFavoriteLocation(userId, location){
-    return database('favorites').insert({location: location, user_id: userId[0].id})
+  async deleteFavoriteLocation(user, location){
+    return database('favorites').where({location: location, user_id: user[0].id}).del()
   }
 }
 

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -37,4 +37,17 @@ router.post('/', async function (request, response) {
   };
 })
 
+router.delete('/', async function (request, response) {
+  let apiKey = request.body.api_key
+  let user = await userObject.findUserByApiKey(apiKey)
+
+  if ( user !== 'undefined'){
+    let location = await request.body.location
+    userObject.deleteFavoriteLocation(user, location)
+    return response.status(204)
+  } else {
+    return response.status(401).send("Unauthorized");
+  };
+})
+
 module.exports = router;


### PR DESCRIPTION
Created DELETE endpoint `api/v1/favorites` that deletes a user's favorited city from favorite table. The location and api_key is passed thru the body.

A valid api_key must be passed in the body of the request. If an invalid api_key is valid, a 401 status is rendered with the message 'Unauthorized'.

Dead functions removed from UserObject model.

Endpoint tested in Postman.